### PR TITLE
Add repo-wide region classification

### DIFF
--- a/Codex/classification.json
+++ b/Codex/classification.json
@@ -1,0 +1,2159 @@
+{
+  "generated_by": "scripts_generate_classification.py",
+  "classifications": [
+    {
+      "path": ".github/FUNDING.yml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": ".gitignore",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "AndroidManifest.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "LICENCE.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "README.md",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 4,
+          "text": "This application translates cutscenes in Fate/Grand Order JP & NA into a variety of different languages. It features real time machine translation of the most recent event using [DeepL](https://www.deepl.com/). Older content uses the official translation from the North American region. Teams of translators are working on human translations in various different languages.",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        },
+        {
+          "line": 33,
+          "text": "2. Log into Fate/Grand Order JP to ensure your game data is up to date - click \"Download\" if promoted for a data update. Afterwards, close the application.",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 84,
+          "text": "### Does this work on NA?",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 149,
+          "text": "Fate/Grand Order is Copyright Aniplex Inc., DELiGHTWORKS, Aniplex of America and Sony Music Entertainment (Japan) Inc. All images and names owned and trademarked by Aniplex Inc., DELiGHTWORKS, Aniplex of America and Sony Music Entertainment (Japan) Inc. are property of their respective owners.",
+          "regions": [
+            "JP"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Assets/AboutAssets.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/MainActivity.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/NextGenFSServiceConnection.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Properties/AndroidManifest.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Properties/AssemblyInfo.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/RayshiftFirebaseMessageService.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 71,
+          "text": "preferencesKey = $\"InstalledScript_{FGORegion.Jp}\";",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 74,
+          "text": "preferencesKey = $\"InstalledScript_{FGORegion.Na}\";",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/RayshiftTranslateFGO.Android.csproj",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/RayshiftTranslationUpdateWorker.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/AboutResources.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/Resource.designer.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/android11.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/english.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/french.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/ic_action_book.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/ic_stat_ic_notification.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/indonesian.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/italian.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/ptbr.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/spanish.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/witcs.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/drawable/zhCN.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/layout/Tabbar.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/layout/Toolbar.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-anydpi-v26/ic_launcher.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-anydpi-v26/ic_launcher_round.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-hdpi/ic_launcher.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-hdpi/ic_launcher_foreground.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-hdpi/ic_launcher_round.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-mdpi/ic_launcher.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-mdpi/ic_launcher_foreground.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-mdpi/ic_launcher_round.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xhdpi/ic_launcher.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xhdpi/ic_launcher_foreground.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xhdpi/ic_launcher_round.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xxhdpi/ic_launcher.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xxhdpi/ic_launcher_foreground.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xxhdpi/ic_launcher_round.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xxxhdpi/ic_launcher.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xxxhdpi/ic_launcher_foreground.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/mipmap-xxxhdpi/ic_launcher_round.png",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/values/colors.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/values/ic_launcher_background.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Resources/values/styles.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/SentryKey.example.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Services/AndroidAlert.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Services/ContentManager.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 482,
+          "text": "? FGORegion.Na",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 483,
+          "text": ": FGORegion.Jp;",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 517,
+          "text": "? FGORegion.Na",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 518,
+          "text": ": FGORegion.Jp;",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 574,
+          "text": "? FGORegion.Na",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 575,
+          "text": ": FGORegion.Jp;",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 625,
+          "text": "? FGORegion.Na",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 626,
+          "text": ": FGORegion.Jp;",
+          "regions": [
+            "JP"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Services/IntentService.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/Services/ScriptManager.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 264,
+          "text": "var prefKey = region == FGORegion.Jp ? \"JPArtChecksums\" : \"NAArtChecksums\";",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO.Android/WebAuthenticationCallbackActivity.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.NextGenFS/Additions/AboutAdditions.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.NextGenFS/Jars/AboutJars.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.NextGenFS/Jars/nextgenfs-debug.aar",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO.NextGenFS/Properties/AssemblyInfo.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.NextGenFS/RayshiftTranslateFGO.NextGenFS.csproj",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.NextGenFS/Transforms/EnumFields.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.NextGenFS/Transforms/EnumMethods.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.NextGenFS/Transforms/Metadata.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO.sln",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Annotations.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/App.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/App.xaml.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/AppResources.Designer.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 881,
+          "text": "///   Looks up a localized string similar to Custom Art (JP).",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 883,
+          "text": "internal static string JPArtName {",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 885,
+          "text": "return ResourceManager.GetString(\"JPArtName\", resourceCulture);",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 890,
+          "text": "///   Looks up a localized string similar to FGO JP.",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 892,
+          "text": "internal static string JPInstaller {",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 894,
+          "text": "return ResourceManager.GetString(\"JPInstaller\", resourceCulture);",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 962,
+          "text": "///   Looks up a localized string similar to Custom Art (NA).",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 964,
+          "text": "internal static string NAArtName {",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 966,
+          "text": "return ResourceManager.GetString(\"NAArtName\", resourceCulture);",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 971,
+          "text": "///   Looks up a localized string similar to FGO NA.",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 973,
+          "text": "internal static string NAInstaller {",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 975,
+          "text": "return ResourceManager.GetString(\"NAInstaller\", resourceCulture);",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/AppResources.es.resx",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 233,
+          "text": "<value>Traducción de la Interfaz de Usuario (Actualmente solo JP/ENG) y Art personalizado solo disponible para donadores de Patreon.",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 237,
+          "text": "<value>Traducción de la Interfaz de Usuario (Actualmente solo JP/ENG) y Art personalizado solo disponible para donadores de Patreon.",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 394,
+          "text": "<data name=\"JPArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 395,
+          "text": "<value>Custom Art (JP)</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 397,
+          "text": "<data name=\"JPInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 398,
+          "text": "<value>FGO JP</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 418,
+          "text": "<data name=\"NAArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 419,
+          "text": "<value>Custom Art (NA)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 421,
+          "text": "<data name=\"NAInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 422,
+          "text": "<value>FGO NA</value>",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/AppResources.fr.resx",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 396,
+          "text": "<data name=\"JPArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 397,
+          "text": "<value>Arts customisées (Jap.)</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 399,
+          "text": "<data name=\"JPInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 400,
+          "text": "<value>FGO Jap.</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 420,
+          "text": "<data name=\"NAArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 421,
+          "text": "<value>Arts customisées (N.A.)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 423,
+          "text": "<data name=\"NAInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 424,
+          "text": "<value>FGO N.A.</value>",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/AppResources.id.resx",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 396,
+          "text": "<data name=\"JPArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 397,
+          "text": "<value>Ilustrasi kustom (JP)</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 399,
+          "text": "<data name=\"JPInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 400,
+          "text": "<value>FGO JP</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 420,
+          "text": "<data name=\"NAArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 421,
+          "text": "<value>Ilustrasi kustom (NA)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 423,
+          "text": "<data name=\"NAInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 424,
+          "text": "<value>FGO NA</value>",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/AppResources.it.resx",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 419,
+          "text": "<data name=\"JPArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 420,
+          "text": "<value>Custom Art (JP)</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 422,
+          "text": "<data name=\"JPInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 423,
+          "text": "<value>FGO JP</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 443,
+          "text": "<data name=\"NAArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 444,
+          "text": "<value>Custom Art (NA)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 446,
+          "text": "<data name=\"NAInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 447,
+          "text": "<value>FGO NA</value>",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/AppResources.pt-BR.resx",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 298,
+          "text": "Falha na soma de verificação em {0}. Comprimento real do arquivo: {1}",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 396,
+          "text": "<data name=\"JPArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 397,
+          "text": "<value>Arte Personalizada (JP)</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 399,
+          "text": "<data name=\"JPInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 400,
+          "text": "<value>FGO JP</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 420,
+          "text": "<data name=\"NAArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 421,
+          "text": "<value>Arte Personalizada (NA)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 423,
+          "text": "<data name=\"NAInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 424,
+          "text": "<value>FGO NA</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 431,
+          "text": "Se você acha que isso é um erro, tente seguir os passos da \"Reconfiguração do Setup do Android 11\" na aba \"Sobre\" primeiro. (erro 1)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 435,
+          "text": "Se você acha que isso é um erro, tente seguir os passos da \"Reconfiguração do setup do Android 11\" na aba \"About\" primeiro. (erro 2)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 483,
+          "text": "<value>Falha na configuração</value>",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/AppResources.resx",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 419,
+          "text": "<data name=\"JPArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 420,
+          "text": "<value>Custom Art (JP)</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 422,
+          "text": "<data name=\"JPInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 423,
+          "text": "<value>FGO JP</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 443,
+          "text": "<data name=\"NAArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 444,
+          "text": "<value>Custom Art (NA)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 446,
+          "text": "<data name=\"NAInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 447,
+          "text": "<value>FGO NA</value>",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/AppResources.zh-Hans.resx",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 396,
+          "text": "<data name=\"JPArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 397,
+          "text": "<value>自定义立绘 (日服)</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 399,
+          "text": "<data name=\"JPInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 400,
+          "text": "<value>FGO 日服</value>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 420,
+          "text": "<data name=\"NAArtName\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 421,
+          "text": "<value>自定义立绘 (美服)</value>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 423,
+          "text": "<data name=\"NAInstaller\" xml:space=\"preserve\">",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 424,
+          "text": "<value>FGO 美服</value>",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/AssemblyInfo.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Fonts/Cabin-SemiBold.ttf",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Models/AssetListAPIResponse.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Models/BaseAPIResponse.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Models/ExtraAssetAPIResponse.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Models/HandshakeAPIResponse.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Models/HyperlinkSpan.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Models/VersionAPIResponse.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/RayshiftTranslateFGO.csproj",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Services/AsyncUploader.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Services/CacheProvider.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Services/IAlert.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Services/ICacheProvider.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Services/IContentManager.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 113,
+          "text": "Jp = 0x1,",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 114,
+          "text": "Na = 0x2,",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/Services/IIntentService.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Services/IScriptManager.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Services/RestfulAPI.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 112,
+          "text": "public async Task<IRestResponse<ArtAPIResponse>> GetArtAPIResponse(string assetStorageJP, string assetStorageNA)",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        },
+        {
+          "line": 128,
+          "text": "if (!string.IsNullOrWhiteSpace(assetStorageJP))",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 130,
+          "text": "sendObject.Add(\"assetstoragejp\", assetStorageJP);",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 132,
+          "text": "if (!string.IsNullOrWhiteSpace(assetStorageNA))",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 134,
+          "text": "sendObject.Add(\"assetstoragena\", assetStorageNA);",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/Util/AppNames.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 10,
+          "text": "\"com.aniplex.fategrandorder.en\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 17,
+          "text": "{ \"com.aniplex.fategrandorder\", \"Fate/Grand Order JP\" },",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 18,
+          "text": "{ \"com.aniplex.fategrandorder.en\", \"Fate/Grand Order NA\" },",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 19,
+          "text": "{ \"io.rayshift.betterfgo\", \"BetterFGO JP\" },",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 20,
+          "text": "{ \"io.rayshift.betterfgo.en\", \"BetterFGO NA\" }",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/Util/EndpointURL.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Util/InstallerUtil.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Util/ScriptUtil.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Util/UIFunctions.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/ViewModels/AboutViewModel.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/ViewModels/BaseViewModel.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/ViewModels/InstallerPageModel.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/ViewModels/MainPageViewModel.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/ViewModels/PreInitializeViewModel.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/ViewModels/ShizukuSetupModel.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/AboutPage.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/AboutPage.xaml.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/AnnouncementPage.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/AnnouncementPage.xaml.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/ArtPage.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/ArtPage.xaml.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 113,
+          "text": "foreach (var region in new[] { FGORegion.Jp, FGORegion.Na })",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        },
+        {
+          "line": 115,
+          "text": "var artUrls = region == FGORegion.Jp",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 150,
+          "text": "Preferences.Remove(\"JPArtChecksums\");",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 151,
+          "text": "Preferences.Remove(\"NAArtChecksums\");",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 307,
+          "text": "_installedFgoInstances.OrderByDescending(o => o.LastModified).FirstOrDefault(w => w.Region == FGORegion.Na);",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 310,
+          "text": "_installedFgoInstances.OrderByDescending(o => o.LastModified).FirstOrDefault(w => w.Region == FGORegion.Jp);",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 351,
+          "text": "foreach(var region in new [] {FGORegion.Jp, FGORegion.Na})",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        },
+        {
+          "line": 354,
+          "text": "var regionEnabled = region == FGORegion.Jp ? JPEnabled : NAEnabled;",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 355,
+          "text": "var instanceDict = region == FGORegion.Jp ? instanceDictJP : instanceDictNA;",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 356,
+          "text": "var status = region == FGORegion.Jp",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 359,
+          "text": "var artUrls = region == FGORegion.Jp",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 363,
+          "text": "var pref = region == FGORegion.Jp",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 364,
+          "text": "? Preferences.Get(\"JPArtChecksums\", \"[]\")",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 365,
+          "text": ": Preferences.Get(\"NAArtChecksums\", \"[]\");",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 428,
+          "text": "Name = region == FGORegion.Jp ? AppResources.JPArtName : AppResources.NAArtName,",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/InstallerPage.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/InstallerPage.xaml.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 31,
+          "text": "public FGORegion Region { get; set; } = FGORegion.Jp;",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 65,
+          "text": "//TranslationName.Text = Region == FGORegion.Jp ? String.Format(AppResources.InstallerTitle, \"JP\") : String.Format(AppResources.InstallerTitle, \"NA\");",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        },
+        {
+          "line": 90,
+          "text": "case FGORegion.Jp:",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 91,
+          "text": "MessagingCenter.Subscribe<Application>(Xamarin.Forms.Application.Current, \"jp_initial_load\", async (sender) =>",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 96,
+          "text": "case FGORegion.Na:",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 97,
+          "text": "MessagingCenter.Subscribe<Application>(Xamarin.Forms.Application.Current, \"na_initial_load\", async (sender) =>",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 111,
+          "text": "if (Region == FGORegion.Jp)",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 221,
+          "text": "//TranslationName.Text = Region == FGORegion.Jp",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 222,
+          "text": "//? String.Format(AppResources.InstallerTitle, \"JP\") + $\": {handshake.Data.Response.AppVer}\"",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 223,
+          "text": "//: String.Format(AppResources.InstallerTitle, \"NA\") + $\": {handshake.Data.Response.AppVer}\";",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/MainPage.xaml",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 14,
+          "text": "<NavigationPage Title=\"{x:Static resources:AppResources.JPInstaller}\">",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 24,
+          "text": "<NavigationPage Title=\"{x:Static resources:AppResources.NAInstaller}\">",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/MainPage.xaml.cs",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 117,
+          "text": "if (title == UIFunctions.GetResourceString(\"NAInstaller\"))",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 119,
+          "text": "MessagingCenter.Send(Xamarin.Forms.Application.Current, \"na_initial_load\");",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 121,
+          "text": "else if (title == UIFunctions.GetResourceString(\"JPInstaller\"))",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 123,
+          "text": "MessagingCenter.Send(Xamarin.Forms.Application.Current, \"jp_initial_load\");",
+          "regions": [
+            "JP"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/PreInitializePage.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/PreInitializePage.xaml.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/SetupPage.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/SetupPage.xaml.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/ShizukuSetup.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/ShizukuSetup.xaml.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/UpdatePage.xaml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "RayshiftTranslateFGO/Views/UpdatePage.xaml.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/LICENSE",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/README.md",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.AIDL/Additions/AboutAdditions.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.AIDL/Jars/AboutJars.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.AIDL/Jars/aidl-release.aar",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.AIDL/Properties/AssemblyInfo.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.AIDL/ShizukuX.AIDL.csproj",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.AIDL/Transforms/EnumFields.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.AIDL/Transforms/EnumMethods.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.AIDL/Transforms/Metadata.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.API/Additions/AboutAdditions.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.API/Jars/AboutJars.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.API/Jars/api-release.aar",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.API/Properties/AssemblyInfo.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.API/ShizukuX.API.csproj",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.API/Transforms/EnumFields.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.API/Transforms/EnumMethods.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.API/Transforms/Metadata.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Provider/Additions/AboutAdditions.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Provider/Jars/AboutJars.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Provider/Jars/provider-release.aar",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Provider/Properties/AssemblyInfo.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Provider/ShizukuX.Provider.csproj",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Provider/Transforms/EnumFields.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Provider/Transforms/EnumMethods.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Provider/Transforms/Metadata.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Shared/Additions/AboutAdditions.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Shared/Jars/AboutJars.txt",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Shared/Jars/shared-release.aar",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Shared/Properties/AssemblyInfo.cs",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Shared/ShizukuX.Shared.csproj",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Shared/Transforms/EnumFields.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Shared/Transforms/EnumMethods.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "ShizukuX/ShizukuX.Shared/Transforms/Metadata.xml",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "native_libs_top30.csv",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "res_xml_listing.csv",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "No region-specific keywords detected"
+    },
+    {
+      "path": "scripts_generate_classification.py",
+      "classification": "shared",
+      "evidence": [
+        {
+          "line": 15,
+          "text": "JP_PATTERNS = compile_patterns([",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 17,
+          "text": "r\"(?<![a-z])JP(?![a-z])\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 20,
+          "text": "r\"Japan\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 21,
+          "text": "r\"Japanese\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 22,
+          "text": "r\"assetstoragejp\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 23,
+          "text": "r\"FGORegion\\.JP\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 24,
+          "text": "r\"Region\\.JP\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 25,
+          "text": "r\"BetterFGO JP\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 26,
+          "text": "r\"Fate/Grand Order JP\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 27,
+          "text": "r\"日服\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 28,
+          "text": "r\"JPArtChecksums\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 29,
+          "text": "r\"JPInstaller\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 30,
+          "text": "r\"JPArtName\",",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 33,
+          "text": "NA_PATTERNS = compile_patterns([",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 35,
+          "text": "r\"(?<![a-z])NA(?![a-z])\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 37,
+          "text": "r\"North America\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 38,
+          "text": "r\"assetstoragena\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 39,
+          "text": "r\"FGORegion\\.NA\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 40,
+          "text": "r\"Region\\.NA\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 41,
+          "text": "r\"BetterFGO NA\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 42,
+          "text": "r\"Fate/Grand Order NA\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 44,
+          "text": "r\"美服\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 45,
+          "text": "r\"NAArtChecksums\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 46,
+          "text": "r\"NAInstaller\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 47,
+          "text": "r\"NAArtName\",",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 85,
+          "text": "matched_jp = any(pattern.search(line) for pattern in JP_PATTERNS)",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 86,
+          "text": "matched_na = any(pattern.search(line) for pattern in NA_PATTERNS)",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 87,
+          "text": "if matched_jp or matched_na:",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        },
+        {
+          "line": 89,
+          "text": "if matched_jp:",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 90,
+          "text": "hit['regions'].add('JP')",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 91,
+          "text": "if matched_na:",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 92,
+          "text": "hit['regions'].add('NA')",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 94,
+          "text": "has_jp = any('JP' in hit['regions'] for hit in line_hits.values())",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 95,
+          "text": "has_na = any('NA' in hit['regions'] for hit in line_hits.values())",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 97,
+          "text": "if has_jp and has_na:",
+          "regions": [
+            "JP",
+            "NA"
+          ]
+        },
+        {
+          "line": 99,
+          "text": "elif has_jp:",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 100,
+          "text": "entry['classification'] = 'jp-only'",
+          "regions": [
+            "JP"
+          ]
+        },
+        {
+          "line": 101,
+          "text": "elif has_na:",
+          "regions": [
+            "NA"
+          ]
+        },
+        {
+          "line": 102,
+          "text": "entry['classification'] = 'na-only'",
+          "regions": [
+            "NA"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tfgo_agent_bundle.zip",
+      "classification": "unknown",
+      "evidence": [],
+      "notes": "Binary or non-text file"
+    }
+  ]
+}

--- a/Codex/classification.md
+++ b/Codex/classification.md
@@ -1,0 +1,162 @@
+# File Region Classification
+
+| File | Classification | Evidence | Notes |
+| --- | --- | --- | --- |
+| `.github/FUNDING.yml` | unknown |  | No region-specific keywords detected |
+| `.gitignore` | unknown |  | No region-specific keywords detected |
+| `AndroidManifest.xml` | unknown |  | Binary or non-text file |
+| `LICENCE.txt` | unknown |  | No region-specific keywords detected |
+| `README.md` | shared | L4: [JP,NA] This application translates cutscenes in Fate/Grand Order JP & NA into a variety of different languages. It features real time machine translation of the most recent event using [DeepL](https://www.deepl.com/). Older content uses the official translation from the North American region. Teams of translators are working on human translations in various different languages.<br>L33: [JP] 2. Log into Fate/Grand Order JP to ensure your game data is up to date - click "Download" if promoted for a data update. Afterwards, close the application.<br>L84: [NA] ### Does this work on NA?<br>L149: [JP] Fate/Grand Order is Copyright Aniplex Inc., DELiGHTWORKS, Aniplex of America and Sony Music Entertainment (Japan) Inc. All images and names owned and trademarked by Aniplex Inc., DELiGHTWORKS, Aniplex of America and Sony Music Entertainment (Japan) Inc. are property of their respective owners. |  |
+| `RayshiftTranslateFGO.Android/Assets/AboutAssets.txt` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/MainActivity.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/NextGenFSServiceConnection.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Properties/AndroidManifest.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Properties/AssemblyInfo.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/RayshiftFirebaseMessageService.cs` | shared | L71: [JP] preferencesKey = $"InstalledScript_{FGORegion.Jp}";<br>L74: [NA] preferencesKey = $"InstalledScript_{FGORegion.Na}"; |  |
+| `RayshiftTranslateFGO.Android/RayshiftTranslateFGO.Android.csproj` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/RayshiftTranslationUpdateWorker.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/AboutResources.txt` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/Resource.designer.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/drawable/android11.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/english.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/french.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/ic_action_book.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/ic_stat_ic_notification.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/indonesian.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/italian.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/ptbr.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/spanish.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/witcs.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/drawable/zhCN.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/layout/Tabbar.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/layout/Toolbar.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-anydpi-v26/ic_launcher.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-anydpi-v26/ic_launcher_round.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-hdpi/ic_launcher.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-hdpi/ic_launcher_foreground.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-hdpi/ic_launcher_round.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-mdpi/ic_launcher.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-mdpi/ic_launcher_foreground.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-mdpi/ic_launcher_round.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xhdpi/ic_launcher.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xhdpi/ic_launcher_foreground.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xhdpi/ic_launcher_round.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xxhdpi/ic_launcher.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xxhdpi/ic_launcher_foreground.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xxhdpi/ic_launcher_round.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xxxhdpi/ic_launcher.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xxxhdpi/ic_launcher_foreground.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/mipmap-xxxhdpi/ic_launcher_round.png` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.Android/Resources/values/colors.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/values/ic_launcher_background.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Resources/values/styles.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/SentryKey.example.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Services/AndroidAlert.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Services/ContentManager.cs` | shared | L482: [NA] ? FGORegion.Na<br>L483: [JP] : FGORegion.Jp;<br>L517: [NA] ? FGORegion.Na<br>L518: [JP] : FGORegion.Jp;<br>L574: [NA] ? FGORegion.Na<br>L575: [JP] : FGORegion.Jp;<br>L625: [NA] ? FGORegion.Na<br>L626: [JP] : FGORegion.Jp; |  |
+| `RayshiftTranslateFGO.Android/Services/IntentService.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.Android/Services/ScriptManager.cs` | shared | L264: [JP,NA] var prefKey = region == FGORegion.Jp ? "JPArtChecksums" : "NAArtChecksums"; |  |
+| `RayshiftTranslateFGO.Android/WebAuthenticationCallbackActivity.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.NextGenFS/Additions/AboutAdditions.txt` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.NextGenFS/Jars/AboutJars.txt` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.NextGenFS/Jars/nextgenfs-debug.aar` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO.NextGenFS/Properties/AssemblyInfo.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.NextGenFS/RayshiftTranslateFGO.NextGenFS.csproj` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.NextGenFS/Transforms/EnumFields.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.NextGenFS/Transforms/EnumMethods.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.NextGenFS/Transforms/Metadata.xml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO.sln` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Annotations.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/App.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/App.xaml.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/AppResources.Designer.cs` | shared | L881: [JP] ///   Looks up a localized string similar to Custom Art (JP).<br>L883: [JP] internal static string JPArtName {<br>L885: [JP] return ResourceManager.GetString("JPArtName", resourceCulture);<br>L890: [JP] ///   Looks up a localized string similar to FGO JP.<br>L892: [JP] internal static string JPInstaller {<br>L894: [JP] return ResourceManager.GetString("JPInstaller", resourceCulture);<br>L962: [NA] ///   Looks up a localized string similar to Custom Art (NA).<br>L964: [NA] internal static string NAArtName {<br>L966: [NA] return ResourceManager.GetString("NAArtName", resourceCulture);<br>L971: [NA] ///   Looks up a localized string similar to FGO NA.<br>L973: [NA] internal static string NAInstaller {<br>L975: [NA] return ResourceManager.GetString("NAInstaller", resourceCulture); |  |
+| `RayshiftTranslateFGO/AppResources.es.resx` | shared | L233: [JP] <value>Traducción de la Interfaz de Usuario (Actualmente solo JP/ENG) y Art personalizado solo disponible para donadores de Patreon.<br>L237: [JP] <value>Traducción de la Interfaz de Usuario (Actualmente solo JP/ENG) y Art personalizado solo disponible para donadores de Patreon.<br>L394: [JP] <data name="JPArtName" xml:space="preserve"><br>L395: [JP] <value>Custom Art (JP)</value><br>L397: [JP] <data name="JPInstaller" xml:space="preserve"><br>L398: [JP] <value>FGO JP</value><br>L418: [NA] <data name="NAArtName" xml:space="preserve"><br>L419: [NA] <value>Custom Art (NA)</value><br>L421: [NA] <data name="NAInstaller" xml:space="preserve"><br>L422: [NA] <value>FGO NA</value> |  |
+| `RayshiftTranslateFGO/AppResources.fr.resx` | shared | L396: [JP] <data name="JPArtName" xml:space="preserve"><br>L397: [JP] <value>Arts customisées (Jap.)</value><br>L399: [JP] <data name="JPInstaller" xml:space="preserve"><br>L400: [JP] <value>FGO Jap.</value><br>L420: [NA] <data name="NAArtName" xml:space="preserve"><br>L421: [NA] <value>Arts customisées (N.A.)</value><br>L423: [NA] <data name="NAInstaller" xml:space="preserve"><br>L424: [NA] <value>FGO N.A.</value> |  |
+| `RayshiftTranslateFGO/AppResources.id.resx` | shared | L396: [JP] <data name="JPArtName" xml:space="preserve"><br>L397: [JP] <value>Ilustrasi kustom (JP)</value><br>L399: [JP] <data name="JPInstaller" xml:space="preserve"><br>L400: [JP] <value>FGO JP</value><br>L420: [NA] <data name="NAArtName" xml:space="preserve"><br>L421: [NA] <value>Ilustrasi kustom (NA)</value><br>L423: [NA] <data name="NAInstaller" xml:space="preserve"><br>L424: [NA] <value>FGO NA</value> |  |
+| `RayshiftTranslateFGO/AppResources.it.resx` | shared | L419: [JP] <data name="JPArtName" xml:space="preserve"><br>L420: [JP] <value>Custom Art (JP)</value><br>L422: [JP] <data name="JPInstaller" xml:space="preserve"><br>L423: [JP] <value>FGO JP</value><br>L443: [NA] <data name="NAArtName" xml:space="preserve"><br>L444: [NA] <value>Custom Art (NA)</value><br>L446: [NA] <data name="NAInstaller" xml:space="preserve"><br>L447: [NA] <value>FGO NA</value> |  |
+| `RayshiftTranslateFGO/AppResources.pt-BR.resx` | shared | L298: [NA] Falha na soma de verificação em {0}. Comprimento real do arquivo: {1}<br>L396: [JP] <data name="JPArtName" xml:space="preserve"><br>L397: [JP] <value>Arte Personalizada (JP)</value><br>L399: [JP] <data name="JPInstaller" xml:space="preserve"><br>L400: [JP] <value>FGO JP</value><br>L420: [NA] <data name="NAArtName" xml:space="preserve"><br>L421: [NA] <value>Arte Personalizada (NA)</value><br>L423: [NA] <data name="NAInstaller" xml:space="preserve"><br>L424: [NA] <value>FGO NA</value><br>L431: [NA] Se você acha que isso é um erro, tente seguir os passos da "Reconfiguração do Setup do Android 11" na aba "Sobre" primeiro. (erro 1)</value><br>L435: [NA] Se você acha que isso é um erro, tente seguir os passos da "Reconfiguração do setup do Android 11" na aba "About" primeiro. (erro 2)</value><br>L483: [NA] <value>Falha na configuração</value> |  |
+| `RayshiftTranslateFGO/AppResources.resx` | shared | L419: [JP] <data name="JPArtName" xml:space="preserve"><br>L420: [JP] <value>Custom Art (JP)</value><br>L422: [JP] <data name="JPInstaller" xml:space="preserve"><br>L423: [JP] <value>FGO JP</value><br>L443: [NA] <data name="NAArtName" xml:space="preserve"><br>L444: [NA] <value>Custom Art (NA)</value><br>L446: [NA] <data name="NAInstaller" xml:space="preserve"><br>L447: [NA] <value>FGO NA</value> |  |
+| `RayshiftTranslateFGO/AppResources.zh-Hans.resx` | shared | L396: [JP] <data name="JPArtName" xml:space="preserve"><br>L397: [JP] <value>自定义立绘 (日服)</value><br>L399: [JP] <data name="JPInstaller" xml:space="preserve"><br>L400: [JP] <value>FGO 日服</value><br>L420: [NA] <data name="NAArtName" xml:space="preserve"><br>L421: [NA] <value>自定义立绘 (美服)</value><br>L423: [NA] <data name="NAInstaller" xml:space="preserve"><br>L424: [NA] <value>FGO 美服</value> |  |
+| `RayshiftTranslateFGO/AssemblyInfo.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Fonts/Cabin-SemiBold.ttf` | unknown |  | Binary or non-text file |
+| `RayshiftTranslateFGO/Models/AssetListAPIResponse.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Models/BaseAPIResponse.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Models/ExtraAssetAPIResponse.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Models/HandshakeAPIResponse.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Models/HyperlinkSpan.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Models/VersionAPIResponse.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/RayshiftTranslateFGO.csproj` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Services/AsyncUploader.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Services/CacheProvider.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Services/IAlert.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Services/ICacheProvider.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Services/IContentManager.cs` | shared | L113: [JP] Jp = 0x1,<br>L114: [NA] Na = 0x2, |  |
+| `RayshiftTranslateFGO/Services/IIntentService.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Services/IScriptManager.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Services/RestfulAPI.cs` | shared | L112: [JP,NA] public async Task<IRestResponse<ArtAPIResponse>> GetArtAPIResponse(string assetStorageJP, string assetStorageNA)<br>L128: [JP] if (!string.IsNullOrWhiteSpace(assetStorageJP))<br>L130: [JP] sendObject.Add("assetstoragejp", assetStorageJP);<br>L132: [NA] if (!string.IsNullOrWhiteSpace(assetStorageNA))<br>L134: [NA] sendObject.Add("assetstoragena", assetStorageNA); |  |
+| `RayshiftTranslateFGO/Util/AppNames.cs` | shared | L10: [NA] "com.aniplex.fategrandorder.en",<br>L17: [JP] { "com.aniplex.fategrandorder", "Fate/Grand Order JP" },<br>L18: [NA] { "com.aniplex.fategrandorder.en", "Fate/Grand Order NA" },<br>L19: [JP] { "io.rayshift.betterfgo", "BetterFGO JP" },<br>L20: [NA] { "io.rayshift.betterfgo.en", "BetterFGO NA" } |  |
+| `RayshiftTranslateFGO/Util/EndpointURL.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Util/InstallerUtil.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Util/ScriptUtil.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Util/UIFunctions.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/ViewModels/AboutViewModel.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/ViewModels/BaseViewModel.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/ViewModels/InstallerPageModel.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/ViewModels/MainPageViewModel.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/ViewModels/PreInitializeViewModel.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/ViewModels/ShizukuSetupModel.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/AboutPage.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/AboutPage.xaml.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/AnnouncementPage.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/AnnouncementPage.xaml.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/ArtPage.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/ArtPage.xaml.cs` | shared | L113: [JP,NA] foreach (var region in new[] { FGORegion.Jp, FGORegion.Na })<br>L115: [JP] var artUrls = region == FGORegion.Jp<br>L150: [JP] Preferences.Remove("JPArtChecksums");<br>L151: [NA] Preferences.Remove("NAArtChecksums");<br>L307: [NA] _installedFgoInstances.OrderByDescending(o => o.LastModified).FirstOrDefault(w => w.Region == FGORegion.Na);<br>L310: [JP] _installedFgoInstances.OrderByDescending(o => o.LastModified).FirstOrDefault(w => w.Region == FGORegion.Jp);<br>L351: [JP,NA] foreach(var region in new [] {FGORegion.Jp, FGORegion.Na})<br>L354: [JP] var regionEnabled = region == FGORegion.Jp ? JPEnabled : NAEnabled;<br>L355: [JP] var instanceDict = region == FGORegion.Jp ? instanceDictJP : instanceDictNA;<br>L356: [JP] var status = region == FGORegion.Jp<br>L359: [JP] var artUrls = region == FGORegion.Jp<br>L363: [JP] var pref = region == FGORegion.Jp<br>L364: [JP] ? Preferences.Get("JPArtChecksums", "[]")<br>L365: [NA] : Preferences.Get("NAArtChecksums", "[]");<br>L428: [JP,NA] Name = region == FGORegion.Jp ? AppResources.JPArtName : AppResources.NAArtName, |  |
+| `RayshiftTranslateFGO/Views/InstallerPage.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/InstallerPage.xaml.cs` | shared | L31: [JP] public FGORegion Region { get; set; } = FGORegion.Jp;<br>L65: [JP,NA] //TranslationName.Text = Region == FGORegion.Jp ? String.Format(AppResources.InstallerTitle, "JP") : String.Format(AppResources.InstallerTitle, "NA");<br>L90: [JP] case FGORegion.Jp:<br>L91: [JP] MessagingCenter.Subscribe<Application>(Xamarin.Forms.Application.Current, "jp_initial_load", async (sender) =><br>L96: [NA] case FGORegion.Na:<br>L97: [NA] MessagingCenter.Subscribe<Application>(Xamarin.Forms.Application.Current, "na_initial_load", async (sender) =><br>L111: [JP] if (Region == FGORegion.Jp)<br>L221: [JP] //TranslationName.Text = Region == FGORegion.Jp<br>L222: [JP] //? String.Format(AppResources.InstallerTitle, "JP") + $": {handshake.Data.Response.AppVer}"<br>L223: [NA] //: String.Format(AppResources.InstallerTitle, "NA") + $": {handshake.Data.Response.AppVer}"; |  |
+| `RayshiftTranslateFGO/Views/MainPage.xaml` | shared | L14: [JP] <NavigationPage Title="{x:Static resources:AppResources.JPInstaller}"><br>L24: [NA] <NavigationPage Title="{x:Static resources:AppResources.NAInstaller}"> |  |
+| `RayshiftTranslateFGO/Views/MainPage.xaml.cs` | shared | L117: [NA] if (title == UIFunctions.GetResourceString("NAInstaller"))<br>L119: [NA] MessagingCenter.Send(Xamarin.Forms.Application.Current, "na_initial_load");<br>L121: [JP] else if (title == UIFunctions.GetResourceString("JPInstaller"))<br>L123: [JP] MessagingCenter.Send(Xamarin.Forms.Application.Current, "jp_initial_load"); |  |
+| `RayshiftTranslateFGO/Views/PreInitializePage.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/PreInitializePage.xaml.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/SetupPage.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/SetupPage.xaml.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/ShizukuSetup.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/ShizukuSetup.xaml.cs` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/UpdatePage.xaml` | unknown |  | No region-specific keywords detected |
+| `RayshiftTranslateFGO/Views/UpdatePage.xaml.cs` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/LICENSE` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/README.md` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.AIDL/Additions/AboutAdditions.txt` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.AIDL/Jars/AboutJars.txt` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.AIDL/Jars/aidl-release.aar` | unknown |  | Binary or non-text file |
+| `ShizukuX/ShizukuX.AIDL/Properties/AssemblyInfo.cs` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.AIDL/ShizukuX.AIDL.csproj` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.AIDL/Transforms/EnumFields.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.AIDL/Transforms/EnumMethods.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.AIDL/Transforms/Metadata.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.API/Additions/AboutAdditions.txt` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.API/Jars/AboutJars.txt` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.API/Jars/api-release.aar` | unknown |  | Binary or non-text file |
+| `ShizukuX/ShizukuX.API/Properties/AssemblyInfo.cs` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.API/ShizukuX.API.csproj` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.API/Transforms/EnumFields.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.API/Transforms/EnumMethods.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.API/Transforms/Metadata.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Provider/Additions/AboutAdditions.txt` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Provider/Jars/AboutJars.txt` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Provider/Jars/provider-release.aar` | unknown |  | Binary or non-text file |
+| `ShizukuX/ShizukuX.Provider/Properties/AssemblyInfo.cs` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Provider/ShizukuX.Provider.csproj` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Provider/Transforms/EnumFields.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Provider/Transforms/EnumMethods.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Provider/Transforms/Metadata.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Shared/Additions/AboutAdditions.txt` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Shared/Jars/AboutJars.txt` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Shared/Jars/shared-release.aar` | unknown |  | Binary or non-text file |
+| `ShizukuX/ShizukuX.Shared/Properties/AssemblyInfo.cs` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Shared/ShizukuX.Shared.csproj` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Shared/Transforms/EnumFields.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Shared/Transforms/EnumMethods.xml` | unknown |  | No region-specific keywords detected |
+| `ShizukuX/ShizukuX.Shared/Transforms/Metadata.xml` | unknown |  | No region-specific keywords detected |
+| `native_libs_top30.csv` | unknown |  | No region-specific keywords detected |
+| `res_xml_listing.csv` | unknown |  | No region-specific keywords detected |
+| `scripts_generate_classification.py` | shared | L15: [JP] JP_PATTERNS = compile_patterns([<br>L17: [JP] r"(?<![a-z])JP(?![a-z])",<br>L20: [JP] r"Japan",<br>L21: [JP] r"Japanese",<br>L22: [JP] r"assetstoragejp",<br>L23: [JP] r"FGORegion\.JP",<br>L24: [JP] r"Region\.JP",<br>L25: [JP] r"BetterFGO JP",<br>L26: [JP] r"Fate/Grand Order JP",<br>L27: [JP] r"日服",<br>L28: [JP] r"JPArtChecksums",<br>L29: [JP] r"JPInstaller",<br>L30: [JP] r"JPArtName",<br>L33: [NA] NA_PATTERNS = compile_patterns([<br>L35: [NA] r"(?<![a-z])NA(?![a-z])",<br>L37: [NA] r"North America",<br>L38: [NA] r"assetstoragena",<br>L39: [NA] r"FGORegion\.NA",<br>L40: [NA] r"Region\.NA",<br>L41: [NA] r"BetterFGO NA",<br>L42: [NA] r"Fate/Grand Order NA",<br>L44: [NA] r"美服",<br>L45: [NA] r"NAArtChecksums",<br>L46: [NA] r"NAInstaller",<br>L47: [NA] r"NAArtName",<br>L85: [JP] matched_jp = any(pattern.search(line) for pattern in JP_PATTERNS)<br>L86: [NA] matched_na = any(pattern.search(line) for pattern in NA_PATTERNS)<br>L87: [JP,NA] if matched_jp or matched_na:<br>L89: [JP] if matched_jp:<br>L90: [JP] hit['regions'].add('JP')<br>L91: [NA] if matched_na:<br>L92: [NA] hit['regions'].add('NA')<br>L94: [JP] has_jp = any('JP' in hit['regions'] for hit in line_hits.values())<br>L95: [NA] has_na = any('NA' in hit['regions'] for hit in line_hits.values())<br>L97: [JP,NA] if has_jp and has_na:<br>L99: [JP] elif has_jp:<br>L100: [JP] entry['classification'] = 'jp-only'<br>L101: [NA] elif has_na:<br>L102: [NA] entry['classification'] = 'na-only' |  |
+| `tfgo_agent_bundle.zip` | unknown |  | Binary or non-text file |

--- a/scripts_generate_classification.py
+++ b/scripts_generate_classification.py
@@ -1,0 +1,145 @@
+import subprocess
+import json
+import re
+from pathlib import Path
+
+def compile_patterns(patterns):
+    compiled = []
+    for pattern in patterns:
+        if isinstance(pattern, tuple):
+            compiled.append(re.compile(pattern[0], pattern[1]))
+        else:
+            compiled.append(re.compile(pattern, re.IGNORECASE))
+    return compiled
+
+JP_PATTERNS = compile_patterns([
+    r"\bJP\b",
+    r"(?<![a-z])JP(?![a-z])",
+    r"J\.P\.",
+    r"Jap\.",
+    r"Japan",
+    r"Japanese",
+    r"assetstoragejp",
+    r"FGORegion\.JP",
+    r"Region\.JP",
+    r"BetterFGO JP",
+    r"Fate/Grand Order JP",
+    r"日服",
+    r"JPArtChecksums",
+    r"JPInstaller",
+    r"JPArtName",
+])
+
+NA_PATTERNS = compile_patterns([
+    r"\bNA\b",
+    r"(?<![a-z])NA(?![a-z])",
+    r"N\.A\.",
+    r"North America",
+    r"assetstoragena",
+    r"FGORegion\.NA",
+    r"Region\.NA",
+    r"BetterFGO NA",
+    r"Fate/Grand Order NA",
+    r"com\.aniplex\.fategrandorder\.en",
+    r"美服",
+    r"NAArtChecksums",
+    r"NAInstaller",
+    r"NAArtName",
+])
+
+root = Path('.')
+ls = subprocess.run(['git', 'ls-files'], capture_output=True, text=True, check=True)
+files = sorted(filter(None, ls.stdout.splitlines()))
+
+records = []
+
+for rel_path in files:
+    path = root / rel_path
+    entry = {
+        'path': rel_path,
+        'classification': None,
+        'evidence': [],
+    }
+    notes = None
+    try:
+        text = path.read_text(encoding='utf-8')
+    except UnicodeDecodeError:
+        try:
+            text = path.read_text(encoding='utf-8-sig')
+        except Exception:
+            entry['classification'] = 'unknown'
+            notes = 'Binary or non-text file'
+            entry['notes'] = notes
+            records.append(entry)
+            continue
+    except Exception:
+        entry['classification'] = 'unknown'
+        notes = 'Unreadable file'
+        entry['notes'] = notes
+        records.append(entry)
+        continue
+
+    line_hits = {}
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        matched_jp = any(pattern.search(line) for pattern in JP_PATTERNS)
+        matched_na = any(pattern.search(line) for pattern in NA_PATTERNS)
+        if matched_jp or matched_na:
+            hit = line_hits.setdefault(line_no, {'line': line_no, 'text': stripped, 'regions': set()})
+            if matched_jp:
+                hit['regions'].add('JP')
+            if matched_na:
+                hit['regions'].add('NA')
+
+    has_jp = any('JP' in hit['regions'] for hit in line_hits.values())
+    has_na = any('NA' in hit['regions'] for hit in line_hits.values())
+
+    if has_jp and has_na:
+        entry['classification'] = 'shared'
+    elif has_jp:
+        entry['classification'] = 'jp-only'
+    elif has_na:
+        entry['classification'] = 'na-only'
+    else:
+        entry['classification'] = 'unknown'
+        notes = 'No region-specific keywords detected'
+
+    if notes:
+        entry['notes'] = notes
+
+    if line_hits:
+        ordered_hits = []
+        for line_no in sorted(line_hits):
+            hit = line_hits[line_no]
+            ordered_hits.append({
+                'line': hit['line'],
+                'text': hit['text'],
+                'regions': sorted(hit['regions']),
+            })
+        entry['evidence'] = ordered_hits
+
+    records.append(entry)
+
+output_json = {
+    'generated_by': 'scripts_generate_classification.py',
+    'classifications': records,
+}
+
+output_path = root / 'Codex' / 'classification.json'
+output_path.write_text(json.dumps(output_json, indent=2, ensure_ascii=False), encoding='utf-8')
+
+lines = ["# File Region Classification", ""]
+lines.append("| File | Classification | Evidence | Notes |")
+lines.append("| --- | --- | --- | --- |")
+for entry in records:
+    evidence_lines = []
+    for ev in entry.get('evidence', []):
+        regions = ','.join(ev['regions']) if ev['regions'] else ''
+        prefix = f"[{regions}] " if regions else ''
+        evidence_lines.append(f"L{ev['line']}: {prefix}{ev['text']}")
+    evidence_str = "<br>".join(evidence_lines) if evidence_lines else ""
+    notes_str = entry.get('notes', '') or ''
+    lines.append(f"| `{entry['path']}` | {entry['classification']} | {evidence_str} | {notes_str} |")
+
+md_path = root / 'Codex' / 'classification.md'
+md_path.write_text("\n".join(lines) + "\n", encoding='utf-8')


### PR DESCRIPTION
## Summary
- add a reusable script that scans tracked files for JP/NA markers
- generate Codex/classification.json and Codex/classification.md with evidence-backed region labels for every file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5cf95601c8333aaa26f6b3abb0130